### PR TITLE
Removed the dependency gem version from Gemspec

### DIFF
--- a/nafath.gemspec
+++ b/nafath.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
-  spec.add_dependency "httparty", "~> 0.22.0"
-  spec.add_dependency "jwt", "~> 2.10.1"
+  spec.add_dependency "httparty"
+  spec.add_dependency "jwt"
   spec.add_dependency "logger"
 
   spec.add_development_dependency "byebug"


### PR DESCRIPTION
**What: **
- Removed the jwt and httparty version from Gemspec.

**Why: **
- To resolve the gem compatibility issue while installing the gem on any project.